### PR TITLE
 - pointAtPercentOfLength: function now ensures percent value is in t…

### DIFF
--- a/UIBezierPath+Length.h
+++ b/UIBezierPath+Length.h
@@ -1,4 +1,4 @@
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @interface UIBezierPath (Length)
 


### PR DESCRIPTION
- pointAtPercentOfLength: function now ensures percent value is in the range 0-1
- the edge case where the overall path is length 0 is now correctly accounted for
- changing the approach from boxing structs in an array of NSValue objects to using a block to enumerate subpaths

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/imjcabus/uibezierpath-length/2)

<!-- Reviewable:end -->
